### PR TITLE
CHAL-44 #done - Enable realtime updates on badges table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@paralleldrive/cuid2": "^2.2.2",
         "@supabase/ssr": "^0.4.0",
         "@supabase/supabase-js": "^2.44.0",
-        "fully-formed": "^1.2.1",
+        "fully-formed": "^1.2.2",
         "luxon": "^3.4.4",
         "next": "^14.2.4",
         "react": "^18.3.1",
@@ -19,7 +19,7 @@
         "react-icons": "^5.0.1",
         "react-turnstile": "^1.1.3",
         "server-only": "^0.0.1",
-        "undecorated-di": "^2.0.0",
+        "undecorated-di": "^2.0.1",
         "zip-state": "^1.0.3",
         "zod": "^3.23.8"
       },
@@ -11831,9 +11831,9 @@
       }
     },
     "node_modules/fully-formed": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fully-formed/-/fully-formed-1.2.1.tgz",
-      "integrity": "sha512-QZr6XWK5VKN7xftt7O8V/LviQjBcJ5CGDAozCSoNO+eygzD4OAGise6K2iALZS3Y3gFq6byEUuB11rKeITwZ9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/fully-formed/-/fully-formed-1.2.2.tgz",
+      "integrity": "sha512-rZdSaDk9ovgC0GT/T/WsfC4JhPnUuhPKgIPN3KCyH3lVFotY2sENFCkF8CuSK0R/AP+1n7uVcyTHDtuuU+FU4w==",
       "license": "MIT",
       "dependencies": {
         "just-clone": "^6.2.0",
@@ -19776,9 +19776,9 @@
       }
     },
     "node_modules/supabase": {
-      "version": "1.192.5",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-1.192.5.tgz",
-      "integrity": "sha512-xRn5wu4jtSgaPXfNrYRYv6Y1oxevxp7Ff95rJyhh1Us7WqSxjmJcpFygXG/tZx/Oxp/iD1JMhip+mFVlfcaVcw==",
+      "version": "1.200.3",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-1.200.3.tgz",
+      "integrity": "sha512-3NdhqBkfPVlm+rAhWQoVcyr54kykuAlHav/GWaAoQEHBDbbYI1lhbDzugk8ryQg92vSLwr3pWz0s4Hjdte8WyQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -20727,9 +20727,9 @@
       }
     },
     "node_modules/undecorated-di": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/undecorated-di/-/undecorated-di-2.0.0.tgz",
-      "integrity": "sha512-f9sjUbXXvYHypr8J6xdq/+xSHKkYl+IXWvi73LLlSCQ6JiiwUQ5hBvBxHk/Ohuj2f33nlxL3HcWe+qiIy95aBA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/undecorated-di/-/undecorated-di-2.0.1.tgz",
+      "integrity": "sha512-Xcp2p/8koPcckCWziyC/E7dIJJPULs0hXmKdoEbEu5sa5MSa1CH0jND7SYOx/vKCJ3/z06L4GiJGyBJh9L9M9A==",
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@paralleldrive/cuid2": "^2.2.2",
     "@supabase/ssr": "^0.4.0",
     "@supabase/supabase-js": "^2.44.0",
-    "fully-formed": "^1.2.1",
+    "fully-formed": "^1.2.2",
     "luxon": "^3.4.4",
     "next": "^14.2.4",
     "react": "^18.3.1",
@@ -30,7 +30,7 @@
     "react-icons": "^5.0.1",
     "react-turnstile": "^1.1.3",
     "server-only": "^0.0.1",
-    "undecorated-di": "^2.0.0",
+    "undecorated-di": "^2.0.1",
     "zip-state": "^1.0.3",
     "zod": "^3.23.8"
   },

--- a/src/__tests__/unit/app/api/refresh-user/refresh-user.test.tsx
+++ b/src/__tests__/unit/app/api/refresh-user/refresh-user.test.tsx
@@ -1,0 +1,128 @@
+import { POST } from '@/app/api/refresh-user/route';
+import { serverContainer } from '@/services/server/container';
+import { SERVER_SERVICE_KEYS } from '@/services/server/keys';
+import { saveActualImplementation } from '@/utils/test/save-actual-implementation';
+import { UserType } from '@/model/enums/user-type';
+import { v4 as uuid } from 'uuid';
+import { DateTime } from 'luxon';
+import { createId } from '@paralleldrive/cuid2';
+import { Builder } from 'builder-pattern';
+import { ServerError } from '@/errors/server-error';
+import type { User } from '@/model/types/user';
+import type { Auth } from '@/services/server/auth/auth';
+
+describe('POST', () => {
+  const getActualService = saveActualImplementation(serverContainer, 'get');
+
+  it('reads the user from the request and returns the user.', async () => {
+    const user: User = {
+      uid: uuid(),
+      name: 'Bob',
+      email: 'bob@example.com',
+      avatar: '3',
+      type: UserType.Challenger,
+      completedActions: {
+        registerToVote: false,
+        electionReminders: false,
+        sharedChallenge: false,
+      },
+      badges: [
+        {
+          playerName: 'Barbara',
+          playerAvatar: '0',
+        },
+      ],
+      challengeEndTimestamp: DateTime.now().plus({ days: 5 }).toUnixInteger(),
+      completedChallenge: false,
+      contributedTo: [],
+      inviteCode: createId(),
+    };
+
+    const containerSpy = jest
+      .spyOn(serverContainer, 'get')
+      .mockImplementationOnce(key => {
+        if (key.name === SERVER_SERVICE_KEYS.Auth.name) {
+          return Builder<Auth>()
+            .loadSessionUser(() => Promise.resolve(user))
+            .build();
+        }
+
+        return getActualService(key);
+      });
+
+    const response = await POST();
+    const data = await response.json();
+    expect(data.user).toEqual(user);
+    containerSpy.mockRestore();
+  });
+
+  it('returns a response with a status of 401 if no user is found.', async () => {
+    const containerSpy = jest
+      .spyOn(serverContainer, 'get')
+      .mockImplementationOnce(key => {
+        if (key.name === SERVER_SERVICE_KEYS.Auth.name) {
+          return Builder<Auth>()
+            .loadSessionUser(() => Promise.resolve(null))
+            .build();
+        }
+
+        return getActualService(key);
+      });
+
+    const response = await POST();
+    expect(response.status).toBe(401);
+    containerSpy.mockRestore();
+  });
+
+  it('returns a response whose status matches that of a caught ServerError.', async () => {
+    const containerSpy = jest
+      .spyOn(serverContainer, 'get')
+      .mockImplementationOnce(key => {
+        if (key.name === SERVER_SERVICE_KEYS.Auth.name) {
+          return Builder<Auth>()
+            .loadSessionUser(() => {
+              throw new ServerError('Too many requests.', 429);
+            })
+            .build();
+        }
+
+        return getActualService(key);
+      });
+
+    /* 
+      Prevent caught error from being logged as it could mislead developers into
+      thinking a test failed.
+    */
+    jest.spyOn(console, 'error').mockImplementationOnce(jest.fn());
+
+    const response = await POST();
+    expect(response.status).toBe(429);
+    containerSpy.mockRestore();
+  });
+
+  it('returns a response with a status of 500 when any other error is caught.', async () => {
+    const containerSpy = jest
+      .spyOn(serverContainer, 'get')
+      .mockImplementationOnce(key => {
+        if (key.name === SERVER_SERVICE_KEYS.Auth.name) {
+          return Builder<Auth>()
+            .loadSessionUser(() => {
+              throw new Error();
+            })
+            .build();
+        }
+
+        return getActualService(key);
+      });
+
+    /* 
+      Prevent caught error from being logged as it could mislead developers into
+      thinking a test failed.
+    */
+    jest.spyOn(console, 'error').mockImplementationOnce(jest.fn());
+
+    const response = await POST();
+    expect(response.status).toBe(500);
+    containerSpy.mockRestore();
+  });
+});

--- a/src/__tests__/unit/app/progress/page.test.tsx
+++ b/src/__tests__/unit/app/progress/page.test.tsx
@@ -8,7 +8,6 @@ import type { User } from '@/model/types/user';
 import { DateTime } from 'luxon';
 import { Actions } from '@/model/enums/actions';
 import userEvent from '@testing-library/user-event';
-import { getErrorThrownByComponent } from '@/utils/test/get-error-thrown-by-component';
 
 jest.mock('next/navigation', () => require('next-router-mock'));
 

--- a/src/__tests__/unit/components/guards/was-invited.test.tsx
+++ b/src/__tests__/unit/components/guards/was-invited.test.tsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import navigation from 'next/navigation';
 import { Builder } from 'builder-pattern';
 import { UserContext, type UserContextType } from '@/contexts/user-context';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 
 jest.mock('next/navigation', () => ({
@@ -22,7 +22,7 @@ describe('wasInvited', () => {
   afterEach(cleanup);
 
   it('returns a component that can be rendered.', () => {
-    const invitedBy = Builder<InvitedBy>().build();
+    const invitedBy = Builder<ChallengerData>().build();
     const userContextValue = Builder<UserContextType>()
       .invitedBy(invitedBy)
       .build();
@@ -40,7 +40,7 @@ describe('wasInvited', () => {
   });
 
   it('returns a component that can accept props.', () => {
-    const invitedBy = Builder<InvitedBy>().build();
+    const invitedBy = Builder<ChallengerData>().build();
     const userContextValue = Builder<UserContextType>()
       .invitedBy(invitedBy)
       .build();
@@ -82,7 +82,7 @@ describe('wasInvited', () => {
   });
 
   it('allows access to a page if invitedBy is not null.', () => {
-    const invitedBy = Builder<InvitedBy>().build();
+    const invitedBy = Builder<ChallengerData>().build();
     const userContextValue = Builder<UserContextType>()
       .invitedBy(invitedBy)
       .build();

--- a/src/__tests__/unit/components/guards/was-not-invited.test.tsx
+++ b/src/__tests__/unit/components/guards/was-not-invited.test.tsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import navigation from 'next/navigation';
 import { Builder } from 'builder-pattern';
 import { UserContext, type UserContextType } from '@/contexts/user-context';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 
 jest.mock('next/navigation', () => ({
@@ -60,7 +60,7 @@ describe('wasNotInvited', () => {
   });
 
   it('redirects the user to /playerwelcome if the invitedBy is not null.', () => {
-    const invitedBy = Builder<InvitedBy>().build();
+    const invitedBy = Builder<ChallengerData>().build();
     const userContextValue = Builder<UserContextType>()
       .invitedBy(invitedBy)
       .build();

--- a/src/__tests__/unit/services/server/auth/supabase-auth.test.ts
+++ b/src/__tests__/unit/services/server/auth/supabase-auth.test.ts
@@ -18,7 +18,7 @@ import type { SupabaseAuthClient } from '@supabase/supabase-js/dist/module/lib/S
 import type { User } from '@/model/types/user';
 import type { InvitationsRepository } from '@/services/server/invitations-repository/invitations-repository';
 import type { ICookies } from '@/services/server/cookies/i-cookies';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 
 describe('SupabaseAuth', () => {
   let supabaseAuth: InstanceType<typeof SupabaseAuth>;
@@ -120,7 +120,7 @@ describe('SupabaseAuth', () => {
   an invite code is detected in cookies and signUpWithEmailAndSendOTP is 
   called.`, async () => {
     const inviteCode = createId();
-    const invitedBy: InvitedBy = {
+    const invitedBy: ChallengerData = {
       challengerName: 'Challenger',
       challengerInviteCode: inviteCode,
       challengerAvatar: '0',
@@ -585,7 +585,7 @@ describe('SupabaseAuth', () => {
       .spyOn(cookies, 'getInviteCode')
       .mockReturnValueOnce(otherUserInviteCode);
 
-    const invitedBy: InvitedBy = {
+    const invitedBy: ChallengerData = {
       challengerName: 'Challenger',
       challengerInviteCode: otherUserInviteCode,
       challengerAvatar: '1',
@@ -684,7 +684,7 @@ describe('SupabaseAuth', () => {
 
     jest.spyOn(userRepository, 'getUserById').mockResolvedValueOnce(user);
 
-    const expectedInvitedBy: InvitedBy = {
+    const expectedInvitedBy: ChallengerData = {
       challengerName: 'Challenger',
       challengerInviteCode: createId(),
       challengerAvatar: '1',
@@ -711,7 +711,7 @@ describe('SupabaseAuth', () => {
       .spyOn(cookies, 'getInviteCode')
       .mockReturnValueOnce(otherUserInviteCode);
 
-    const expectedInvitedBy: InvitedBy = {
+    const expectedInvitedBy: ChallengerData = {
       challengerName: 'Challenger',
       challengerInviteCode: otherUserInviteCode,
       challengerAvatar: '1',

--- a/src/__tests__/unit/services/server/invitations-repository/supabase-invitations-repository.test.ts
+++ b/src/__tests__/unit/services/server/invitations-repository/supabase-invitations-repository.test.ts
@@ -6,7 +6,7 @@ import { createId } from '@paralleldrive/cuid2';
 import { v4 as uuid } from 'uuid';
 import type { InvitationsRepository } from '@/services/server/invitations-repository/invitations-repository';
 import type { CreateSupabaseClient } from '@/services/server/create-supabase-client/create-supabase-client';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 
 describe('SupabaseInvitationsRepository', () => {
   let invitationsRepository: InvitationsRepository;
@@ -145,7 +145,7 @@ describe('SupabaseInvitationsRepository', () => {
     );
     expect(actualInvitedBy).toBeNull();
 
-    const expectedInvitedBy: InvitedBy = {
+    const expectedInvitedBy: ChallengerData = {
       challengerName: 'Challenger',
       challengerAvatar: '2',
       challengerInviteCode: createId(),
@@ -185,7 +185,7 @@ describe('SupabaseInvitationsRepository', () => {
       throw new Error(playerInsertionError.message);
     }
 
-    const initialInvitedBy: InvitedBy = {
+    const initialInvitedBy: ChallengerData = {
       challengerName: 'Challenger',
       challengerAvatar: '2',
       challengerInviteCode: createId(),
@@ -202,7 +202,7 @@ describe('SupabaseInvitationsRepository', () => {
 
     expect(actualInvitedBy).toStrictEqual(initialInvitedBy);
 
-    const updatedInvitedBy: InvitedBy = {
+    const updatedInvitedBy: ChallengerData = {
       challengerName: 'Another Challenger',
       challengerAvatar: '3',
       challengerInviteCode: createId(),

--- a/src/__tests__/unit/services/server/user-record-parser/user-record-parser.test.ts
+++ b/src/__tests__/unit/services/server/user-record-parser/user-record-parser.test.ts
@@ -1,6 +1,7 @@
 import { Actions } from '@/model/enums/actions';
 import { UserType } from '@/model/enums/user-type';
 import { UserRecordParser } from '@/services/server/user-record-parser/user-record-parser';
+import { createId } from '@paralleldrive/cuid2';
 import { DateTime } from 'luxon';
 
 describe('UserRecordParser', () => {
@@ -43,6 +44,7 @@ describe('UserRecordParser', () => {
     ],
     contributed_to: [
       {
+        challenger_invite_code: createId(),
         challenger_name: 'user 3',
         challenger_avatar: '2',
       },
@@ -81,8 +83,10 @@ describe('UserRecordParser', () => {
       ],
       contributedTo: [
         {
-          name: 'user 3',
-          avatar: '2',
+          challengerInviteCode:
+            validUser.contributed_to[0].challenger_invite_code,
+          challengerName: 'user 3',
+          challengerAvatar: '2',
         },
       ],
     });
@@ -175,17 +179,30 @@ describe('UserRecordParser', () => {
     const invalidContributedToEntries = [
       {},
       {
-        challenger_name: 'challenger name without avatar',
+        challenger_name: '',
+        challenger_avatar: '',
       },
       {
+        challenger_invite_code: '',
         challenger_avatar: '0',
       },
       {
+        challenger_invite_code: '',
+        challenger_name: '',
+      },
+      {
+        challenger_invite_code: 1,
+        challenger_name: '',
+        challenger_avatar: '0',
+      },
+      {
+        challenger_invite_code: '',
         challenger_name: 1,
         challenger_avatar: '0',
       },
       {
-        challenger_name: 'challenger name with invalid avatar',
+        challenger_invite_code: '',
+        challenger_name: '',
         challenger_avatar: '4',
       },
     ];

--- a/src/__tests__/unit/services/server/user-repository/supabase-user-repository.test.ts
+++ b/src/__tests__/unit/services/server/user-repository/supabase-user-repository.test.ts
@@ -8,6 +8,8 @@ import { ServerError } from '@/errors/server-error';
 import { SupabaseUserRecordBuilder } from '@/utils/test/supabase-user-record-builder';
 import { createId } from '@paralleldrive/cuid2';
 import { createSupabaseServiceRoleClient } from '@/services/server/create-supabase-client/create-supabase-service-role-client';
+import { serverContainer } from '@/services/server/container';
+import { SERVER_SERVICE_KEYS } from '@/services/server/keys';
 import type { CreateSupabaseClient } from '@/services/server/create-supabase-client/create-supabase-client';
 import type { IUserRecordParser } from '@/services/server/user-record-parser/i-user-record-parser';
 import type { Badge } from '@/model/types/badges/badge';
@@ -146,8 +148,8 @@ describe('SupabaseUserRepository', () => {
     });
   });
 
-  it(`throws a ServerError if supabase.rpc() returns an error when getUserById is 
-  called.`, async () => {
+  it(`throws a ServerError if supabase.rpc() returns an error when getUserById
+  is called.`, async () => {
     const errorMessage = 'test error message';
 
     createSupabaseClient = jest.fn().mockImplementation(() => {
@@ -172,7 +174,7 @@ describe('SupabaseUserRepository', () => {
     );
   });
 
-  it(`throws a ServerError if UserRecordParser.parseUserRecord throws an error 
+  it(`throws a ServerError if UserRecordParser.parseUserRecord throws an error
   when getUserById is called.`, async () => {
     createSupabaseClient = jest.fn().mockImplementation(() => {
       return {
@@ -200,7 +202,7 @@ describe('SupabaseUserRepository', () => {
     );
   });
 
-  it(`updates the user to a hybrid type user and returns the updated user when 
+  it(`updates the user to a hybrid type user and returns the updated user when
   makeHybrid() is called.`, async () => {
     const supabase = createSupabaseClient();
 
@@ -262,8 +264,9 @@ describe('SupabaseUserRepository', () => {
     ]);
   });
 
-  it(`updates the player's contributedTo when awardElectionRemindersBadge is
-    called and the player has not yet contributed to the inviting challenger.`, async () => {
+  it(`inserts a new record into the player's contributedTo when
+  makeHybrid is called and the player has not yet contributed
+  to the inviting challenger.`, async () => {
     const challenger = await new SupabaseUserRecordBuilder(
       'challenger@example.com',
     ).build();
@@ -287,7 +290,7 @@ describe('SupabaseUserRepository', () => {
     ]);
   });
 
-  it(`throws a ServerError when the update operation initiated by 
+  it(`throws a ServerError when the update operation initiated by
   makeHybrid fails.`, () => {
     createSupabaseClient = jest.fn().mockImplementation(() => {
       return {
@@ -363,7 +366,7 @@ describe('SupabaseUserRepository', () => {
     );
   });
 
-  it(`sets completedActions.electionReminders to true when 
+  it(`sets completedActions.electionReminders to true when
   awardElectionRemindersBadge is called.`, async () => {
     let user = await new SupabaseUserRecordBuilder('user@example.com').build();
     expect(user.completedActions.electionReminders).toBe(false);
@@ -401,7 +404,7 @@ describe('SupabaseUserRepository', () => {
     expect(user.completedChallenge).toBe(true);
   });
 
-  it(`does not award the user a badge when awardElectionRemindersBadge is 
+  it(`does not award the user a badge when awardElectionRemindersBadge is
   called and the user has already completed this action.`, async () => {
     let user = await new SupabaseUserRecordBuilder('user@example.com')
       .completedActions({
@@ -467,8 +470,9 @@ describe('SupabaseUserRepository', () => {
     ]);
   });
 
-  it(`updates the player's contributedTo when awardElectionRemindersBadge is
-  called and the player has not yet contributed to the inviting challenger.`, async () => {
+  it(`inserts a new record into the player's contributedTo when
+  awardElectionRemindersBadge is called and the player has not yet contributed
+  to the inviting challenger.`, async () => {
     const challenger = await new SupabaseUserRecordBuilder(
       'challenger@example.com',
     ).build();
@@ -492,7 +496,7 @@ describe('SupabaseUserRepository', () => {
     ]);
   });
 
-  it(`does not update the player's contributedTo when
+  it(`does not insert a new record into the player's contributedTo when
   awardElectionRemindersBadge is called, but the player has already contributed
   to the inviting challenger's challenge.`, async () => {
     const playerName = 'Player';
@@ -626,7 +630,7 @@ describe('SupabaseUserRepository', () => {
     expect(updatedChallenger?.badges).toHaveLength(8);
   });
 
-  it(`throws a ServerError if supabase.rpc() returns an error when 
+  it(`throws a ServerError if supabase.rpc() returns an error when
   awardElectionRemindersBadge is called.`, async () => {
     const errorMessage = 'test error message';
 
@@ -652,7 +656,7 @@ describe('SupabaseUserRepository', () => {
     ).rejects.toThrow(new ServerError(errorMessage, 429));
   });
 
-  it(`throws an error if the user returned by supabase.rpc() is null when 
+  it(`throws an error if the user returned by supabase.rpc() is null when
   awardElectionRemindersBadge is called.`, async () => {
     createSupabaseClient = jest.fn().mockImplementation(() => {
       return {
@@ -698,7 +702,7 @@ describe('SupabaseUserRepository', () => {
     ).rejects.toThrow(new ServerError('Failed to parse user data.', 400));
   });
 
-  it(`sets completedActions.registerToVote to true when 
+  it(`sets completedActions.registerToVote to true when
   awardRegisterToVoteBadge is called.`, async () => {
     let user = await new SupabaseUserRecordBuilder('user@example.com').build();
     expect(user.completedActions.registerToVote).toBe(false);
@@ -736,7 +740,7 @@ describe('SupabaseUserRepository', () => {
     expect(user.completedChallenge).toBe(true);
   });
 
-  it(`does not award the user a badge when awardRegisterToVoteBadge is 
+  it(`does not award the user a badge when awardRegisterToVoteBadge is
   called and the user has already completed this action.`, async () => {
     let user = await new SupabaseUserRecordBuilder('user@example.com')
       .completedActions({
@@ -754,7 +758,7 @@ describe('SupabaseUserRepository', () => {
     expect(user.badges).toHaveLength(1);
   });
 
-  it(`does not award a badge when awardRegisterToVoteBadge is called and the 
+  it(`does not award a badge when awardRegisterToVoteBadge is called and the
   user already has 8 badges.`, async () => {
     let user = await new SupabaseUserRecordBuilder('user@example.com')
       .badges(
@@ -802,8 +806,9 @@ describe('SupabaseUserRepository', () => {
     ]);
   });
 
-  it(`updates the player's contributedTo when awardRegisterToVoteBadge is
-  called and the player has not yet contributed to the inviting challenger.`, async () => {
+  it(`inserts a new record into the player's contributedTo when
+  awardRegisterToVoteBadge is called and the player has not yet contributed to
+  the inviting challenger.`, async () => {
     const challenger = await new SupabaseUserRecordBuilder(
       'challenger@example.com',
     ).build();
@@ -827,7 +832,7 @@ describe('SupabaseUserRepository', () => {
     ]);
   });
 
-  it(`does not update the player's contributedTo when
+  it(`does not insert a new record into the player's contributedTo when
   awardRegisterToVoteBadge is called, but the player has already contributed
   to the inviting challenger's challenge.`, async () => {
     const playerName = 'Player';
@@ -961,7 +966,7 @@ describe('SupabaseUserRepository', () => {
     expect(updatedChallenger?.badges).toHaveLength(8);
   });
 
-  it(`throws a ServerError if supabase.rpc() returns an error when 
+  it(`throws a ServerError if supabase.rpc() returns an error when
   awardRegisterToVoteBadge is called.`, async () => {
     const errorMessage = 'test error message';
 
@@ -987,7 +992,7 @@ describe('SupabaseUserRepository', () => {
     );
   });
 
-  it(`throws an error if the user returned by supabase.rpc() is null when 
+  it(`throws an error if the user returned by supabase.rpc() is null when
   awardRegisterToVoteBadge is called.`, async () => {
     createSupabaseClient = jest.fn().mockImplementation(() => {
       return {
@@ -1031,5 +1036,89 @@ describe('SupabaseUserRepository', () => {
     await expect(userRepository.awardRegisterToVoteBadge('')).rejects.toThrow(
       new ServerError('Failed to parse user data.', 400),
     );
+  });
+
+  it(`sorts contributedTo by the time at which the player last contributed to 
+  that challenger, with the most recently contributed to challenger sorted 
+  to the end of the array.`, async () => {
+    const challengerA = await new SupabaseUserRecordBuilder(
+      'challenger.a@example.com',
+    )
+      .name('Challenger A')
+      .build();
+    const challengerB = await new SupabaseUserRecordBuilder(
+      'challenger.b@example.com',
+    )
+      .name('Challenger B')
+      .build();
+
+    const player = await new SupabaseUserRecordBuilder('player@example.com')
+      .type(UserType.Player)
+      .invitedBy({
+        challengerInviteCode: challengerA.inviteCode,
+        challengerName: challengerA.name,
+        challengerAvatar: challengerA.avatar,
+      })
+      .name('Player')
+      .build();
+
+    await userRepository.awardElectionRemindersBadge(player.uid);
+
+    let { contributedTo } = (await userRepository.getUserById(player.uid))!;
+    expect(contributedTo).toEqual([
+      {
+        challengerInviteCode: challengerA.inviteCode,
+        challengerName: challengerA.name,
+        challengerAvatar: challengerA.avatar,
+      },
+    ]);
+
+    const invitationsRepo = serverContainer.get(
+      SERVER_SERVICE_KEYS.InvitationsRepository,
+    );
+
+    await invitationsRepo.insertOrUpdateInvitedBy(player.uid, {
+      challengerInviteCode: challengerB.inviteCode,
+      challengerName: challengerB.name,
+      challengerAvatar: challengerB.avatar,
+    });
+
+    await userRepository.awardRegisterToVoteBadge(player.uid);
+    contributedTo = (await userRepository.getUserById(player.uid))!
+      .contributedTo;
+    expect(contributedTo).toEqual([
+      {
+        challengerInviteCode: challengerA.inviteCode,
+        challengerName: challengerA.name,
+        challengerAvatar: challengerA.avatar,
+      },
+      {
+        challengerInviteCode: challengerB.inviteCode,
+        challengerName: challengerB.name,
+        challengerAvatar: challengerB.avatar,
+      },
+    ]);
+
+    await invitationsRepo.insertOrUpdateInvitedBy(player.uid, {
+      challengerInviteCode: challengerA.inviteCode,
+      challengerName: challengerA.name,
+      challengerAvatar: challengerA.avatar,
+    });
+
+    await userRepository.makeHybrid(player.uid);
+    contributedTo = (await userRepository.getUserById(player.uid))!
+      .contributedTo;
+    expect(contributedTo).toEqual([
+      {
+        challengerInviteCode: challengerB.inviteCode,
+        challengerName: challengerB.name,
+        challengerAvatar: challengerB.avatar,
+      },
+      {
+        challengerInviteCode: challengerA.inviteCode,
+        challengerName: challengerA.name,
+        challengerAvatar: challengerA.avatar,
+      },
+    ]);
   });
 });

--- a/src/__tests__/unit/services/server/user-repository/supabase-user-repository.test.ts
+++ b/src/__tests__/unit/services/server/user-repository/supabase-user-repository.test.ts
@@ -68,9 +68,9 @@ describe('SupabaseUserRepository', () => {
       .avatar('1')
       .completedActions({ registerToVote: true })
       .invitedBy({
-        name: challengerName,
-        avatar: challengerAvatar,
-        inviteCode: challengerInviteCode,
+        challengerName,
+        challengerAvatar,
+        challengerInviteCode,
       })
       .badges([
         {
@@ -79,9 +79,9 @@ describe('SupabaseUserRepository', () => {
       ])
       .contributedTo([
         {
-          name: challengerName,
-          inviteCode: challengerInviteCode,
-          avatar: challengerAvatar,
+          challengerName,
+          challengerInviteCode,
+          challengerAvatar,
         },
       ])
       .build();
@@ -137,8 +137,9 @@ describe('SupabaseUserRepository', () => {
       completedChallenge: false,
       contributedTo: [
         {
-          name: challengerName,
-          avatar: challengerAvatar,
+          challengerInviteCode,
+          challengerName,
+          challengerAvatar,
         },
       ],
       inviteCode: expect.any(String),
@@ -241,9 +242,9 @@ describe('SupabaseUserRepository', () => {
     const player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .name('Player')
       .avatar('3')
@@ -270,17 +271,18 @@ describe('SupabaseUserRepository', () => {
     let player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .build();
 
     player = await userRepository.makeHybrid(player.uid);
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       },
     ]);
   });
@@ -445,9 +447,9 @@ describe('SupabaseUserRepository', () => {
     const player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .name('Player')
       .avatar('3')
@@ -474,17 +476,18 @@ describe('SupabaseUserRepository', () => {
     let player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .build();
 
     player = await userRepository.awardElectionRemindersBadge(player.uid);
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       },
     ]);
   });
@@ -509,9 +512,9 @@ describe('SupabaseUserRepository', () => {
     let player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .completedActions({ registerToVote: true })
       .badges([
@@ -521,17 +524,18 @@ describe('SupabaseUserRepository', () => {
       ])
       .contributedTo([
         {
-          inviteCode: challenger.inviteCode,
-          name: challenger.name,
-          avatar: challenger.avatar,
+          challengerInviteCode: challenger.inviteCode,
+          challengerName: challenger.name,
+          challengerAvatar: challenger.avatar,
         },
       ])
       .build();
 
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       },
     ]);
 
@@ -539,8 +543,9 @@ describe('SupabaseUserRepository', () => {
 
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       },
     ]);
   });
@@ -566,9 +571,9 @@ describe('SupabaseUserRepository', () => {
     )
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .completedActions({ electionReminders: true })
       .badges([
@@ -606,9 +611,9 @@ describe('SupabaseUserRepository', () => {
     )
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .build();
 
@@ -777,9 +782,9 @@ describe('SupabaseUserRepository', () => {
     const player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .name('Player')
       .avatar('3')
@@ -806,17 +811,18 @@ describe('SupabaseUserRepository', () => {
     let player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .build();
 
     player = await userRepository.awardRegisterToVoteBadge(player.uid);
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       },
     ]);
   });
@@ -841,9 +847,9 @@ describe('SupabaseUserRepository', () => {
     let player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .completedActions({ electionReminders: true })
       .badges([
@@ -853,17 +859,18 @@ describe('SupabaseUserRepository', () => {
       ])
       .contributedTo([
         {
-          inviteCode: challenger.inviteCode,
-          name: challenger.name,
-          avatar: challenger.avatar,
+          challengerInviteCode: challenger.inviteCode,
+          challengerName: challenger.name,
+          challengerAvatar: challenger.avatar,
         },
       ])
       .build();
 
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       },
     ]);
 
@@ -871,8 +878,9 @@ describe('SupabaseUserRepository', () => {
 
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       },
     ]);
   });
@@ -898,9 +906,9 @@ describe('SupabaseUserRepository', () => {
     )
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .completedActions({ registerToVote: true })
       .badges([
@@ -938,9 +946,9 @@ describe('SupabaseUserRepository', () => {
     )
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challenger.inviteCode,
-        name: challenger.name,
-        avatar: challenger.avatar,
+        challengerInviteCode: challenger.inviteCode,
+        challengerName: challenger.name,
+        challengerAvatar: challenger.avatar,
       })
       .build();
 

--- a/src/__tests__/unit/utils/test/supabase-user-record-builder.test.ts
+++ b/src/__tests__/unit/utils/test/supabase-user-record-builder.test.ts
@@ -6,7 +6,7 @@ import { DateTime } from 'luxon';
 import { UserType } from '@/model/enums/user-type';
 import { Actions } from '@/model/enums/actions';
 import type { Avatar } from '@/model/types/avatar';
-import type { Badge } from '@/model/types/badge';
+import type { Badge } from '@/model/types/badges/badge';
 import { createSupabaseServiceRoleClient } from '@/services/server/create-supabase-client/create-supabase-service-role-client';
 
 describe('SupabaseUserRecordBuilder', () => {
@@ -155,9 +155,9 @@ describe('SupabaseUserRecordBuilder', () => {
     const player = await new SupabaseUserRecordBuilder('player@example.com')
       .type(UserType.Player)
       .invitedBy({
-        inviteCode: challengerInviteCode,
-        name: challengerName,
-        avatar: challengerAvatar,
+        challengerInviteCode,
+        challengerName,
+        challengerAvatar,
       })
       .build();
 
@@ -170,9 +170,9 @@ describe('SupabaseUserRecordBuilder', () => {
     );
 
     expect(invitedBy).toStrictEqual({
-      challengerInviteCode: challengerInviteCode,
-      challengerName: challengerName,
-      challengerAvatar: challengerAvatar,
+      challengerInviteCode,
+      challengerName,
+      challengerAvatar,
     });
   });
 
@@ -185,17 +185,18 @@ describe('SupabaseUserRecordBuilder', () => {
       .type(UserType.Player)
       .contributedTo([
         {
-          inviteCode: challengerInviteCode,
-          name: challengerName,
-          avatar: challengerAvatar,
+          challengerInviteCode,
+          challengerName,
+          challengerAvatar,
         },
       ])
       .build();
 
     expect(player.contributedTo).toStrictEqual([
       {
-        name: challengerName,
-        avatar: challengerAvatar,
+        challengerInviteCode,
+        challengerName,
+        challengerAvatar,
       },
     ]);
   });

--- a/src/app/api/refresh-user/route.ts
+++ b/src/app/api/refresh-user/route.ts
@@ -1,0 +1,32 @@
+import 'server-only';
+import { serverContainer } from '@/services/server/container';
+import { SERVER_SERVICE_KEYS } from '@/services/server/keys';
+import { NextResponse } from 'next/server';
+import { ServerError } from '@/errors/server-error';
+
+export async function POST() {
+  try {
+    const auth = serverContainer.get(SERVER_SERVICE_KEYS.Auth);
+    const user = await auth.loadSessionUser();
+
+    if (!user) {
+      return NextResponse.json({ message: 'Unauthorized.' }, { status: 401 });
+    }
+
+    return NextResponse.json({ user }, { status: 200 });
+  } catch (e) {
+    console.error(e);
+
+    if (e instanceof ServerError) {
+      return NextResponse.json(
+        { message: e.message },
+        { status: e.statusCode },
+      );
+    }
+
+    return NextResponse.json(
+      { message: 'An unknown error occurred.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/contexts/user-context/client-side-user-context-provider.tsx
+++ b/src/contexts/user-context/client-side-user-context-provider.tsx
@@ -11,7 +11,7 @@ import { clearInviteCode } from './clear-invite-code-cookie';
 import { clearAllPersistentFormElements, ValueOf } from 'fully-formed';
 import { VoterRegistrationForm } from '@/app/register/voter-registration-form';
 import type { User } from '@/model/types/user';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 
 /**
  * Props that can be passed from a server component into a
@@ -21,7 +21,7 @@ import type { InvitedBy } from '@/model/types/invited-by';
 interface ClientSideUserContextProviderProps {
   user: User | null;
   emailForSignIn: string;
-  invitedBy: InvitedBy | null;
+  invitedBy: ChallengerData | null;
   children?: ReactNode;
 }
 
@@ -38,7 +38,9 @@ export function ClientSideUserContextProvider(
 ) {
   const [user, setUser] = useState<User | null>(props.user);
   const [emailForSignIn, setEmailForSignIn] = useState(props.emailForSignIn);
-  const [invitedBy, setInvitedBy] = useState<InvitedBy | null>(props.invitedBy);
+  const [invitedBy, setInvitedBy] = useState<ChallengerData | null>(
+    props.invitedBy,
+  );
   const router = useRouter();
 
   useEffect(() => {
@@ -98,7 +100,7 @@ export function ClientSideUserContextProvider(
 
     const data = await response.json();
     setUser(data.user as User);
-    setInvitedBy(data.invitedBy as InvitedBy);
+    setInvitedBy(data.invitedBy as ChallengerData);
   }
 
   async function gotElectionReminders() {

--- a/src/contexts/user-context/user-context.tsx
+++ b/src/contexts/user-context/user-context.tsx
@@ -4,7 +4,7 @@ import { VoterRegistrationForm } from '@/app/register/voter-registration-form';
 import type { User } from '../../model/types/user';
 import type { Avatar } from '@/model/types/avatar';
 import type { ValueOf } from 'fully-formed';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 
 interface SignUpWithEmailParams {
   email: string;
@@ -25,7 +25,7 @@ interface SignInWithOTPParams {
 interface UserContextType {
   user: User | null;
   emailForSignIn: string;
-  invitedBy: InvitedBy | null;
+  invitedBy: ChallengerData | null;
   signUpWithEmail(params: SignUpWithEmailParams): Promise<void>;
   sendOTPToEmail(params: SendOTPToEmailParams): Promise<void>;
   resendOTP(): Promise<void>;

--- a/src/model/types/challenger-data.ts
+++ b/src/model/types/challenger-data.ts
@@ -1,6 +1,6 @@
 import type { Avatar } from './avatar';
 
-export interface InvitedBy {
+export interface ChallengerData {
   challengerInviteCode: string;
   challengerName: string;
   challengerAvatar: Avatar;

--- a/src/model/types/session.ts
+++ b/src/model/types/session.ts
@@ -1,7 +1,7 @@
 import type { User } from './user';
-import type { InvitedBy } from './invited-by';
+import type { ChallengerData } from './challenger-data';
 
 export interface Session {
   user: User | null;
-  invitedBy: InvitedBy | null;
+  invitedBy: ChallengerData | null;
 }

--- a/src/model/types/user.ts
+++ b/src/model/types/user.ts
@@ -1,6 +1,7 @@
 import { UserType } from '../enums/user-type';
 import type { Avatar } from './avatar';
 import type { Badge } from './badges/badge';
+import type { ChallengerData } from './challenger-data';
 
 export interface User {
   uid: string;
@@ -27,7 +28,7 @@ export interface User {
    * The names and avatars of these challengers are displayed on
    * the /actions page once the player has completed all possible actions.
    */
-  contributedTo: Array<{ name: string; avatar: Avatar }>;
+  contributedTo: Array<ChallengerData>;
   /**
    * The most recent challenger to invite the player.
    *

--- a/src/services/server/auth/supabase-auth.ts
+++ b/src/services/server/auth/supabase-auth.ts
@@ -10,7 +10,7 @@ import type { CreateSupabaseClient } from '../create-supabase-client/create-supa
 import type { UserRepository } from '../user-repository/user-repository';
 import type { Avatar } from '@/model/types/avatar';
 import type { InvitationsRepository } from '../invitations-repository/invitations-repository';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 import type { ICookies } from '../cookies/i-cookies';
 import type { Session } from '@/model/types/session';
 
@@ -187,11 +187,11 @@ export const SupabaseAuth = inject(
       return { user, invitedBy };
     }
 
-    private async loadInvitedByForGuest(): Promise<InvitedBy | null> {
+    private async loadInvitedByForGuest(): Promise<ChallengerData | null> {
       return this.loadInvitedByFromCookies();
     }
 
-    private async loadInvitedByFromCookies(): Promise<InvitedBy | null> {
+    private async loadInvitedByFromCookies(): Promise<ChallengerData | null> {
       const inviteCode = this.cookies.getInviteCode();
 
       if (inviteCode) {
@@ -206,7 +206,7 @@ export const SupabaseAuth = inject(
       return null;
     }
 
-    private isInvitedByValid(invitedBy: InvitedBy, user: User) {
+    private isInvitedByValid(invitedBy: ChallengerData, user: User) {
       return invitedBy.challengerInviteCode !== user.inviteCode;
     }
   },

--- a/src/services/server/invitations-repository/invitations-repository.ts
+++ b/src/services/server/invitations-repository/invitations-repository.ts
@@ -1,12 +1,12 @@
-import { InvitedBy } from '@/model/types/invited-by';
+import { ChallengerData } from '@/model/types/challenger-data';
 
 export interface InvitationsRepository {
   getInvitedByFromChallengerInviteCode(
     inviteCode: string,
-  ): Promise<InvitedBy | null>;
-  getInvitedByFromPlayerId(playerId: string): Promise<InvitedBy | null>;
+  ): Promise<ChallengerData | null>;
+  getInvitedByFromPlayerId(playerId: string): Promise<ChallengerData | null>;
   insertOrUpdateInvitedBy(
     playerId: string,
-    invitedBy: InvitedBy,
+    invitedBy: ChallengerData,
   ): Promise<void>;
 }

--- a/src/services/server/invitations-repository/supabase-invitations-repository.ts
+++ b/src/services/server/invitations-repository/supabase-invitations-repository.ts
@@ -3,7 +3,7 @@ import { SERVER_SERVICE_KEYS } from '../keys';
 import { ServerError } from '@/errors/server-error';
 import type { InvitationsRepository } from './invitations-repository';
 import type { CreateSupabaseClient } from '../create-supabase-client/create-supabase-client';
-import type { InvitedBy } from '@/model/types/invited-by';
+import type { ChallengerData } from '@/model/types/challenger-data';
 
 export const SupabaseInvitationsRepository = inject(
   class SupabaseInvitationsRepository implements InvitationsRepository {
@@ -11,7 +11,7 @@ export const SupabaseInvitationsRepository = inject(
 
     async getInvitedByFromChallengerInviteCode(
       inviteCode: string,
-    ): Promise<InvitedBy | null> {
+    ): Promise<ChallengerData | null> {
       const supabase = this.createSupabaseClient();
 
       const { data } = await supabase
@@ -34,7 +34,7 @@ export const SupabaseInvitationsRepository = inject(
 
     async getInvitedByFromPlayerId(
       playerId: string,
-    ): Promise<InvitedBy | null> {
+    ): Promise<ChallengerData | null> {
       const supabase = this.createSupabaseClient();
 
       const { data } = await supabase
@@ -57,7 +57,7 @@ export const SupabaseInvitationsRepository = inject(
 
     async insertOrUpdateInvitedBy(
       playerId: string,
-      invitedBy: InvitedBy,
+      invitedBy: ChallengerData,
     ): Promise<void> {
       const supabase = this.createSupabaseClient();
 

--- a/src/services/server/user-record-parser/user-record-parser.ts
+++ b/src/services/server/user-record-parser/user-record-parser.ts
@@ -44,6 +44,7 @@ export const UserRecordParser = inject(
     }
 
     private dbContributedToSchema = z.object({
+      challenger_invite_code: z.string(),
       challenger_name: z.string(),
       challenger_avatar: z.enum(['0', '1', '2', '3']),
     });
@@ -90,8 +91,9 @@ export const UserRecordParser = inject(
           }
         }),
         contributedTo: validatedDBUser.contributed_to.map(contributedTo => ({
-          name: contributedTo.challenger_name,
-          avatar: contributedTo.challenger_avatar,
+          challengerInviteCode: contributedTo.challenger_invite_code,
+          challengerName: contributedTo.challenger_name,
+          challengerAvatar: contributedTo.challenger_avatar,
         })),
         challengeEndTimestamp: validatedDBUser.challenge_end_timestamp,
         completedChallenge: validatedDBUser.completed_challenge,

--- a/src/services/server/user-repository/supabase-user-repository.ts
+++ b/src/services/server/user-repository/supabase-user-repository.ts
@@ -19,6 +19,7 @@ export const SupabaseUserRepository = inject(
       GET_USER_BY_ID: 'get_user_by_id',
       AWARD_ELECTION_REMINDERS_BADGE: 'award_election_reminders_badge',
       AWARD_REGISTER_TO_VOTE_BADGE: 'award_register_to_vote_badge',
+      MAKE_HYBRID: 'make_hybrid',
     };
 
     constructor(
@@ -58,21 +59,9 @@ export const SupabaseUserRepository = inject(
         data: dbUser,
         error,
         status,
-      } = await supabase
-        .from('users')
-        .update({
-          user_type: UserType.Hybrid,
-        })
-        .eq('id', userId)
-        .select(
-          `*,
-          completed_actions (election_reminders, register_to_vote, shared_challenge),
-          badges (action_type, player_name, player_avatar),
-          contributed_to (challenger_name, challenger_avatar)`,
-        )
-        .order('id')
-        .limit(1)
-        .maybeSingle();
+      } = await supabase.rpc(this.REMOTE_PROCEDURES.MAKE_HYBRID, {
+        user_id: userId,
+      });
 
       if (error) {
         throw new ServerError(error.message, status);

--- a/src/utils/test/supabase-user-record-builder.ts
+++ b/src/utils/test/supabase-user-record-builder.ts
@@ -10,6 +10,7 @@ import { PRIVATE_ENVIRONMENT_VARIABLES } from '@/constants/private-environment-v
 import { UserRecordParser } from '@/services/server/user-record-parser/user-record-parser';
 import type { User } from '@/model/types/user';
 import type { Avatar } from '@/model/types/avatar';
+import type { ChallengerData } from '@/model/types/challenger-data';
 import type { Badge } from '@/model/types/badges/badge';
 
 interface UserRecord {
@@ -43,22 +44,10 @@ interface PlayerBadgeRecord {
   player_avatar: Avatar;
 }
 
-interface InvitedBy {
-  inviteCode: string;
-  name: string;
-  avatar: Avatar;
-}
-
 interface InvitedByRecord {
   challenger_invite_code: string;
   challenger_name: string;
   challenger_avatar: Avatar;
-}
-
-interface ContributedTo {
-  name: string;
-  inviteCode: string;
-  avatar: Avatar;
 }
 
 interface ContributedToRecord {
@@ -147,23 +136,23 @@ export class SupabaseUserRecordBuilder {
     return this;
   }
 
-  invitedBy(invitedBy: InvitedBy) {
+  invitedBy(invitedBy: ChallengerData) {
     this.invitedByRecord = {
-      challenger_invite_code: invitedBy.inviteCode,
-      challenger_name: invitedBy.name,
-      challenger_avatar: invitedBy.avatar,
+      challenger_invite_code: invitedBy.challengerInviteCode,
+      challenger_name: invitedBy.challengerName,
+      challenger_avatar: invitedBy.challengerAvatar,
     };
 
     return this;
   }
 
-  contributedTo(contributedTo: Array<ContributedTo>) {
+  contributedTo(contributedTo: Array<ChallengerData>) {
     this.contributedToRecords = contributedTo.map(
-      ({ name, inviteCode, avatar }) => {
+      ({ challengerName, challengerInviteCode, challengerAvatar }) => {
         return {
-          challenger_name: name,
-          challenger_invite_code: inviteCode,
-          challenger_avatar: avatar,
+          challenger_name: challengerName,
+          challenger_invite_code: challengerInviteCode,
+          challenger_avatar: challengerAvatar,
         };
       },
     );

--- a/supabase/migrations/20240711063356_initial_schema.sql
+++ b/supabase/migrations/20240711063356_initial_schema.sql
@@ -76,6 +76,7 @@ create table public.contributed_to (
   challenger_invite_code varchar not null,
   challenger_name varchar(255) not null,
   challenger_avatar char(1) not null,
+  contributed_to_at timestamp not null default current_timestamp,
   primary key (id, player_id)
 );
 

--- a/supabase/migrations/20240711063356_initial_schema.sql
+++ b/supabase/migrations/20240711063356_initial_schema.sql
@@ -43,6 +43,7 @@ create table public.badges (
   player_name varchar(255),
   player_avatar char(1),
   challenger_id uuid not null references public.users on delete cascade,
+  awarded_at timestamp not null default current_timestamp,
   primary key (id, challenger_id)
 );
 

--- a/supabase/migrations/20240911054315_add_get_user_by_id.sql
+++ b/supabase/migrations/20240911054315_add_get_user_by_id.sql
@@ -74,6 +74,7 @@ begin
     select (action_type, player_name, player_avatar)::badge_obj
     from badges
     where badges.challenger_id = user_id
+    order by badges.awarded_at asc
   ) into user.badges;
 
   select array(

--- a/supabase/migrations/20240911054315_add_get_user_by_id.sql
+++ b/supabase/migrations/20240911054315_add_get_user_by_id.sql
@@ -16,8 +16,9 @@ create type badge_obj as (
 );
 
 create type contributed_to_obj as (
+  challenger_invite_code varchar(30),
   challenger_name varchar(255),
-  challenger_avatar char(1),
+  challenger_avatar char(1)
 );
 
 create type user_obj as (
@@ -78,7 +79,7 @@ begin
   ) into user.badges;
 
   select array(
-    select (challenger_name, challenger_avatar)::contributed_to_obj
+    select (challenger_invite_code, challenger_name, challenger_avatar)::contributed_to_obj
     from contributed_to
     where contributed_to.player_id = user_id
     order by contributed_to.contributed_to_at asc

--- a/supabase/migrations/20240911054315_add_get_user_by_id.sql
+++ b/supabase/migrations/20240911054315_add_get_user_by_id.sql
@@ -76,6 +76,7 @@ begin
     from badges
     where badges.challenger_id = user_id
     order by badges.awarded_at asc
+    limit 8
   ) into user.badges;
 
   select array(

--- a/supabase/migrations/20240911054315_add_get_user_by_id.sql
+++ b/supabase/migrations/20240911054315_add_get_user_by_id.sql
@@ -17,7 +17,7 @@ create type badge_obj as (
 
 create type contributed_to_obj as (
   challenger_name varchar(255),
-  challenger_avatar char(1)
+  challenger_avatar char(1),
 );
 
 create type user_obj as (
@@ -81,6 +81,7 @@ begin
     select (challenger_name, challenger_avatar)::contributed_to_obj
     from contributed_to
     where contributed_to.player_id = user_id
+    order by contributed_to.contributed_to_at asc
   ) into user.contributed_to;
 
   return user;

--- a/supabase/migrations/20240911054415_add_award_election_reminders_badge.sql
+++ b/supabase/migrations/20240911054415_add_award_election_reminders_badge.sql
@@ -71,6 +71,10 @@ begin
       update_contributed_to.challenger_name, 
       update_contributed_to.challenger_avatar
     );
+  else 
+    update contributed_to set contributed_to_at = current_timestamp
+    where contributed_to.player_id = update_contributed_to.player_id
+    and contributed_to.challenger_invite_code = update_contributed_to.challenger_invite_code;
   end if;
 end;
 $$;

--- a/supabase/migrations/20240925054529_add_make_hybrid.sql
+++ b/supabase/migrations/20240925054529_add_make_hybrid.sql
@@ -1,0 +1,52 @@
+create function make_player_hybrid(user_id uuid)
+returns void
+language plpgsql strict
+security invoker
+as 
+$$
+<<make_player_hybrid_body>>
+declare
+  challenger_invite_code varchar;
+begin
+  update users set user_type = 'hybrid'
+  where users.id = make_player_hybrid.user_id
+  and users.user_type = 'player';
+
+  if found = true then
+    select invited_by.challenger_invite_code from invited_by
+    into make_player_hybrid_body.challenger_invite_code
+    where invited_by.player_id = make_player_hybrid.user_id;
+
+    if make_player_hybrid_body.challenger_invite_code is not null then
+      perform award_badge_to_challenger(user_id, challenger_invite_code);
+    end if;
+  end if;
+end;
+$$;
+
+create function make_hybrid(user_id uuid)
+returns record
+language plpgsql strict
+security invoker
+as
+$$
+<<make_hybrid_body>>
+declare 
+  user_type varchar;
+begin 
+  select users.user_type from public.users
+  into make_hybrid_body.user_type
+  where users.id = make_hybrid.user_id;
+
+  if make_hybrid_body.user_type = 'player' then
+    perform make_player_hybrid(user_id);
+  else
+    if make_hybrid_body.user_type = 'challenger' then
+      update users set user_type = 'hybrid'
+      where users.id = make_hybrid.user_id;
+    end if;
+  end if;
+
+  return get_user_by_id(user_id);
+end;
+$$;

--- a/supabase/migrations/20240925094941_enable_realtime_on_badges.sql
+++ b/supabase/migrations/20240925094941_enable_realtime_on_badges.sql
@@ -1,0 +1,2 @@
+alter
+  publication supabase_realtime add table badges;


### PR DESCRIPTION
## Checklist
- [x] Include the corresponding Jira issue key and #done in the PR title, like so: "JRA-123 #done Migrate Election Reminders"
- [x] Verify that the code compiles (npm run dev)
- [x] Verify that the project builds (npm run build)
- [x] Verify that all tests pass
- [x] Verify that unit tests cover 100% of the code
- [ ] <s>Create Storybook stories for visual components</s> N/A
- [ ] <s>Verify that any visual components match the Figma</s> N/A
- [ ] <s>Test with a screen reader (if applicable)</s> N/A
- [x] Document your code with TSDoc comments
- [x] Format your code with Prettier

## Overview
This PR enables Supabase realtime updates on the badges table. In the frontend, the `ClientSideUserContextProvider` subscribes to these changes. If a badge has been awarded to the challenger due to the actions of a player, the `User` object is refreshed. When the user signs out, the subscription is unsubscribed from. When the refresh user operation returns, the `User` object is only updated if the id of the signed in user matches the id of the user that was retrieved from the database, preventing issues due to potential race conditions.

Other updates have been made to the data model. Badges have an `awarded_at` timestamp and are ordered by this timestamp when retrieved from the database, guaranteeing that the user always sees their badges displayed in the same order. Similarly, the `contributed_to` table now as a `contributed_to_at` field. If a record for a given challenger-player combination already exists in this table, this timestamp is updated, ensuring that each challenger-player combination is only represented once in the table, but that when an array of these is returned for a player, the challenger that they contributed to most recently is always returned last. This is important for displaying the /actions page correctly.

Finally, the `makeHybrid` function now awards an inviting challenger a badge when a player they invited takes the challenge and is upgraded to a challenger.

## Test Plan
I updated the tests for `SupabaseUserRepository` and several other classes to reflect these changes. I also added tests to ensure that the `contributedTo` array is returned in the correct order and that realtime updates are propagated to the DOM. Finally, I verified this behavior manually by using the Supabase dashboard to add badges while signed in to the app and observed them appear in the DOM.

## Follow ups
After reviewing the Figma, I noticed that the a challenger should not get a badge when a player they invited shares the challenge (though the player does get a badge), but SHOULD get a badge when that player becomes a challenger (whereas in this case, the player is the one who is NOT awarded a badge). The `makeHybrid` method of the `SupabaseUserRepository`  meets these requirements, but `awardSharedBadge` will also need to do so once it is implemented.