### PR TITLE
CHAL-78 #done - Add guards to PlayerWelcome page

### DIFF
--- a/src/__tests__/unit/app/playerwelcome/page.test.tsx
+++ b/src/__tests__/unit/app/playerwelcome/page.test.tsx
@@ -27,7 +27,7 @@ describe('PlayerWelcome', () => {
 
   afterEach(cleanup);
 
-  it("renders text including the challenger's name when invitedBy is not null.", () => {
+  it("renders text including the challenger's name.", () => {
     const challengerName = 'John Smith';
 
     render(
@@ -44,6 +44,7 @@ describe('PlayerWelcome', () => {
         <Page />
       </UserContext.Provider>,
     );
+
     expect(
       screen.queryByText(
         `Help ${challengerName} win their 8by8 Challenge by registering to vote or taking other actions to #stopasianhate!`,
@@ -51,25 +52,17 @@ describe('PlayerWelcome', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders fallback text when invitedBy is null.', () => {
-    render(
-      <UserContext.Provider
-        value={Builder<UserContextType>().user(null).invitedBy(null).build()}
-      >
-        <Page />
-      </UserContext.Provider>,
-    );
-    expect(
-      screen.queryByText(
-        'Help support the AAPI community by registering to vote or taking other actions to #stopasianhate!',
-      ),
-    ).toBeInTheDocument();
-  });
-
   it('calls router.push(/signup) when the user presses the Get Started buttons.', async () => {
     render(
       <UserContext.Provider
-        value={Builder<UserContextType>().user(null).invitedBy(null).build()}
+        value={Builder<UserContextType>()
+          .user(null)
+          .invitedBy({
+            challengerName: 'John Smith',
+            challengerAvatar: '2',
+            challengerInviteCode: '',
+          })
+          .build()}
       >
         <Page />
       </UserContext.Provider>,

--- a/src/app/playerwelcome/page.tsx
+++ b/src/app/playerwelcome/page.tsx
@@ -60,7 +60,7 @@ export default isSignedOut(
 
             <h3>2. Your friend will earn a badge</h3>
             <p className={styles.b2_extend}>
-              Any of the 3 actions will helf your friend earn a badge, and get
+              Any of the 3 actions will help your friend earn a badge, and get
               closer to winning the challenge.
             </p>
             <div className={styles.images}>

--- a/src/app/playerwelcome/page.tsx
+++ b/src/app/playerwelcome/page.tsx
@@ -1,123 +1,125 @@
 'use client';
-import { PageContainer } from '@/components/utils/page-container';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-import { UserContext } from '@/contexts/user-context';
+import { isSignedOut } from '@/components/guards/is-signed-out';
+import { wasInvited } from '@/components/guards/was-invited';
 import { useContextSafely } from '@/hooks/use-context-safely';
-import styles from './styles.module.scss';
+import { UserContext } from '@/contexts/user-context';
+import { PageContainer } from '@/components/utils/page-container';
 import { Button } from '@/components/utils/button';
+import styles from './styles.module.scss';
 
-export default function PlayerWelcome() {
-  const { invitedBy } = useContextSafely(UserContext, 'UserContext');
-  const challengerName =
-    invitedBy?.challengerName ? `${invitedBy.challengerName}'s` : 'the';
-  const subtitleText =
-    invitedBy ?
-      `Help ${invitedBy.challengerName} win their 8by8 Challenge by registering to vote or taking other actions to #stopasianhate!`
-    : 'Help support the AAPI community by registering to vote or taking other actions to #stopasianhate!';
+export default isSignedOut(
+  wasInvited(function PlayerWelcome() {
+    const { invitedBy } = useContextSafely(UserContext, 'UserContext');
 
-  const router = useRouter();
-  useEffect(() => {
-    router.prefetch('/signup');
-  }, [router]);
+    const router = useRouter();
+    useEffect(() => {
+      router.prefetch('/signup');
+    }, [router]);
 
-  return (
-    <PageContainer>
-      <div className={styles.banner}>
-        <h1 className="mt_md mb_md">
-          <span className="underline">Support</span> {challengerName}
-          <br /> 8by8 Challenge!
-        </h1>
-        <p className={styles.subtitle}>{subtitleText}</p>
-        <Button
-          size="lg"
-          wide
-          onClick={() => {
-            router.push('/signup');
-          }}
-        >
-          Get started
-        </Button>
-        <p className={styles.signin_link}>
-          Already have an account?{' '}
-          <Link href="/signin" className="link--teal">
-            Sign In
-          </Link>
-        </p>
-      </div>
-
-      <div className={styles.curve}></div>
-
-      <div className={styles.explanation}>
-        <h1 className={styles.title}>
-          <span className="underline">Here&apos;s how it works</span>
-        </h1>
-        <div>
-          <h3>1. Choose an action to take</h3>
-          <p className={styles.b2_extend}>
-            You can take any number of available actions: register to vote, get
-            election reminders, or take the 8by8 challenge yourself. Pick one to
-            start.
+    return (
+      <PageContainer>
+        <div className={styles.banner}>
+          <h1 className="mt_md mb_md">
+            <span className="underline">Support</span>{' '}
+            {invitedBy!.challengerName}&apos;s
+            <br /> 8by8 Challenge!
+          </h1>
+          <p className={styles.subtitle}>
+            Help {invitedBy!.challengerName} win their 8by8 Challenge by
+            registering to vote or taking other actions to #stopasianhate!
           </p>
-          <div className={styles.images}>
-            <Image
-              src="/static/images/pages/playerwelcome/person-with-take-action-sign.png"
-              width={206}
-              height={139}
-              alt="person holding a take action sign"
-            />
-          </div>
-
-          <h3>2. Your friend will earn a badge</h3>
-          <p className={styles.b2_extend}>
-            Any of the 3 actions will helf your friend earn a badge, and get
-            closer to winning the challenge.
-          </p>
-          <div className={styles.images}>
-            <Image
-              src="/static/images/pages/playerwelcome/cell-phone.png"
-              width={128}
-              height={127}
-              alt="cell phone with a crown image on the screen"
-            />
-          </div>
-
-          <h3>3. Come back and take more actions</h3>
-          <p className={styles.b2_extend}>
-            Whether it is to help the same friend or a different one, the more
-            action you take, the better! Note that you can only earn one badge
-            per friend.
-          </p>
-          <div className={styles.image_last}>
-            <Image
-              src="/static/images/pages/playerwelcome/person-with-we-need-your-help-sign.png"
-              width={141}
-              height={141}
-              alt="person holding a sign saying we need your help"
-            />
-          </div>
-
-          <div>
-            <Button
-              size="lg"
-              wide
-              onClick={() => {
-                router.push('/signup');
-              }}
-            >
-              Get started
-            </Button>
-          </div>
+          <Button
+            size="lg"
+            wide
+            onClick={() => {
+              router.push('/signup');
+            }}
+          >
+            Get started
+          </Button>
           <p className={styles.signin_link}>
             Already have an account?{' '}
-            <Link href="/signin" className="link">
+            <Link href="/signin" className="link--teal">
               Sign In
             </Link>
           </p>
         </div>
-      </div>
-    </PageContainer>
-  );
-}
+
+        <div className={styles.curve}></div>
+
+        <div className={styles.explanation}>
+          <h1 className={styles.title}>
+            <span className="underline">Here&apos;s how it works</span>
+          </h1>
+          <div>
+            <h3>1. Choose an action to take</h3>
+            <p className={styles.b2_extend}>
+              You can take any number of available actions: register to vote,
+              get election reminders, or take the 8by8 challenge yourself. Pick
+              one to start.
+            </p>
+            <div className={styles.images}>
+              <Image
+                src="/static/images/pages/playerwelcome/person-with-take-action-sign.png"
+                width={206}
+                height={139}
+                alt="person holding a take action sign"
+              />
+            </div>
+
+            <h3>2. Your friend will earn a badge</h3>
+            <p className={styles.b2_extend}>
+              Any of the 3 actions will helf your friend earn a badge, and get
+              closer to winning the challenge.
+            </p>
+            <div className={styles.images}>
+              <Image
+                src="/static/images/pages/playerwelcome/cell-phone.png"
+                width={128}
+                height={127}
+                alt="cell phone with a crown image on the screen"
+              />
+            </div>
+
+            <h3>3. Come back and take more actions</h3>
+            <p className={styles.b2_extend}>
+              Whether it is to help the same friend or a different one, the more
+              action you take, the better! Note that you can only earn one badge
+              per friend.
+            </p>
+            <div className={styles.image_last}>
+              <Image
+                src="/static/images/pages/playerwelcome/person-with-we-need-your-help-sign.png"
+                width={141}
+                height={141}
+                alt="person holding a sign saying we need your help"
+              />
+            </div>
+
+            <div>
+              <Button
+                size="lg"
+                wide
+                onClick={() => {
+                  router.push('/signup');
+                }}
+              >
+                Get started
+              </Button>
+            </div>
+            <p className={styles.signin_link}>
+              Already have an account?{' '}
+              <Link href="/signin" className="link">
+                Sign In
+              </Link>
+            </p>
+          </div>
+        </div>
+      </PageContainer>
+    );
+  }),
+);

--- a/src/app/playerwelcome/page.tsx
+++ b/src/app/playerwelcome/page.tsx
@@ -1,6 +1,4 @@
 'use client';
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { isSignedOut } from '@/components/guards/is-signed-out';
@@ -8,17 +6,12 @@ import { wasInvited } from '@/components/guards/was-invited';
 import { useContextSafely } from '@/hooks/use-context-safely';
 import { UserContext } from '@/contexts/user-context';
 import { PageContainer } from '@/components/utils/page-container';
-import { Button } from '@/components/utils/button';
+import { LinkButton } from '@/components/utils/link-button';
 import styles from './styles.module.scss';
 
 export default isSignedOut(
   wasInvited(function PlayerWelcome() {
     const { invitedBy } = useContextSafely(UserContext, 'UserContext');
-
-    const router = useRouter();
-    useEffect(() => {
-      router.prefetch('/signup');
-    }, [router]);
 
     return (
       <PageContainer>
@@ -32,15 +25,9 @@ export default isSignedOut(
             Help {invitedBy!.challengerName} win their 8by8 Challenge by
             registering to vote or taking other actions to #stopasianhate!
           </p>
-          <Button
-            size="lg"
-            wide
-            onClick={() => {
-              router.push('/signup');
-            }}
-          >
+          <LinkButton size="lg" wide href="/signup">
             Get started
-          </Button>
+          </LinkButton>
           <p className={styles.signin_link}>
             Already have an account?{' '}
             <Link href="/signin" className="link--teal">
@@ -101,15 +88,9 @@ export default isSignedOut(
             </div>
 
             <div>
-              <Button
-                size="lg"
-                wide
-                onClick={() => {
-                  router.push('/signup');
-                }}
-              >
+              <LinkButton size="lg" wide href="/signup">
                 Get started
-              </Button>
+              </LinkButton>
             </div>
             <p className={styles.signin_link}>
               Already have an account?{' '}

--- a/src/stories/pages/playerwelcome.stories.tsx
+++ b/src/stories/pages/playerwelcome.stories.tsx
@@ -58,17 +58,3 @@ export const LongName: Story = {
     );
   },
 };
-
-export const NoInvite: Story = {
-  render: () => {
-    return (
-      <GlobalStylesProvider>
-        <UserContext.Provider
-          value={Builder<UserContextType>().user(null).invitedBy(null).build()}
-        >
-          <PlayerWelcome />
-        </UserContext.Provider>
-      </GlobalStylesProvider>
-    );
-  },
-};


### PR DESCRIPTION
## Checklist
- [x] Include the corresponding Jira issue key and #done in the PR title, like so: "JRA-123 #done Migrate Election Reminders"
- [x] Verify that the code compiles (npm run dev)
- [x] Verify that the project builds (npm run build)
- [x] Verify that all tests pass
- [x] Verify that unit tests cover 100% of the code
- [x] Create Storybook stories for visual components
- [x] Verify that any visual components match the Figma
- [x] Test with a screen reader (if applicable)
- [x] Document your code with TSDoc comments
- [x] Format your code with Prettier

## Overview
This PR adds guards to the PlayerWelcome page, preventing access to the page unless the user is signed out and has been invited by a challenger. If signed in, the user is redirected to either /progress or /actions depending on their type, and if signed out but uninvited, the user is redirected to /challengerwelcome. Because the guards render `null` instead of the protected page if the user is to be redirected, the `invitedBy` object cannot be null within the page. Therefore, fallback text and corresponding tests and stories were removed, as they are unreachable.

Finally, in the interest of cleaning as we go, the calls to `useEffect` and `router.prefetch` and the `Button` components in this page have been replaced with the new `LinkButton` component, which is an extension of the `Button` component that calls `router.prefetch` upon mount and navigates to the `href` it receives as a prop when clicked.

## Test Plan
I updated the tests and Storybook stories to reflect the changes to the page. 100% code coverage has been maintained.
