### PR TITLE
CHAL-83 #done - Add csp and csrf protection

### DIFF
--- a/.github/workflows/deploy-and-test-staging-branch.yml
+++ b/.github/workflows/deploy-and-test-staging-branch.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - staging
 
+env:
+  SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
 jobs:
   reset-db:
     runs-on: ubuntu-latest
@@ -12,7 +15,6 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-production-branch.yml
+++ b/.github/workflows/deploy-production-branch.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - production
 
+env:
+  SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
 jobs:
   run-migrations:
     runs-on: ubuntu-latest
@@ -12,7 +15,6 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,18 @@
+const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'unsafe-inline' ${process.env.NODE_ENV === 'production' ? '' : "'unsafe-eval'"} https://register.rockthevote.com;
+    frame-src https://register.rockthevote.com;
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' blob: data:;
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    block-all-mixed-content;
+    upgrade-insecure-requests;
+`;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   /*
@@ -14,6 +29,10 @@ const nextConfig = {
           {
             key: 'cache-control',
             value: 'public, max-age=31536000, immutable',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeader.replace(/\n/g, ''),
           },
         ],
       },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,17 +1,4 @@
-const cspHeader = `
-    default-src 'self';
-    script-src 'self' 'unsafe-inline' ${process.env.NODE_ENV === 'production' ? '' : "'unsafe-eval'"} https://register.rockthevote.com;
-    frame-src https://register.rockthevote.com;
-    style-src 'self' 'unsafe-inline';
-    img-src 'self' blob: data:;
-    font-src 'self';
-    object-src 'none';
-    base-uri 'self';
-    form-action 'self';
-    frame-ancestors 'none';
-    block-all-mixed-content;
-    upgrade-insecure-requests;
-`;
+import { createCSP } from './scripts/create-content-security-policy.mjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -30,11 +17,11 @@ const nextConfig = {
             key: 'cache-control',
             value: 'public, max-age=31536000, immutable',
           },
-          {
-            key: 'Content-Security-Policy',
-            value: cspHeader.replace(/\n/g, ''),
-          },
         ],
+      },
+      {
+        source: '/(.*)',
+        headers: [createCSP()],
       },
     ];
   },

--- a/scripts/create-content-security-policy.mjs
+++ b/scripts/create-content-security-policy.mjs
@@ -1,0 +1,137 @@
+const KeywordValues = {
+  None: "'none'",
+  Self: "'self'",
+  UnsafeInline: "'unsafe-inline'",
+  UnsafeEval: "'unsafe-eval'",
+};
+
+const ExternalSources = {
+  RockTheVote: 'https://register.rockthevote.com/',
+  RockyAPIAssets: 'https://s3.amazonaws.com/rocky-assets/',
+  Cloudflare: 'https://challenges.cloudflare.com/',
+};
+
+/**
+ * Creates the Content Security Policy header depending on the environment.
+ *
+ * For more information about the CSP header, please see
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP}.
+ */
+export function createCSP() {
+  const directives = [
+    {
+      directive: 'default-src',
+      values: [KeywordValues.Self],
+    },
+    {
+      directive: 'script-src',
+      values: getAllowedScriptSources(),
+    },
+    {
+      /*
+        Allow Rock the Vote's Pledge to Vote form and the Cloudflare Turnstile 
+        widget to be rendered in IFrames.
+      */
+      directive: 'frame-src',
+      values: [ExternalSources.RockTheVote, ExternalSources.Cloudflare],
+    },
+    {
+      directive: 'connect-src',
+      values: [KeywordValues.Self, getSupabaseRealtimeSocketURL()],
+    },
+    {
+      directive: 'style-src',
+      values: [KeywordValues.Self, KeywordValues.UnsafeInline],
+    },
+    {
+      directive: 'img-src',
+      values: [KeywordValues.Self, 'blob:', 'data:'],
+    },
+    {
+      directive: 'font-src',
+      values: [KeywordValues.Self],
+    },
+    {
+      directive: 'object-src',
+      values: [KeywordValues.None],
+    },
+    {
+      directive: 'base-uri',
+      values: [KeywordValues.Self],
+    },
+    {
+      directive: 'form-action',
+      // will this allow the election reminders form to be submitted?
+      values: [KeywordValues.Self],
+    },
+    {
+      directive: 'frame-ancestors',
+      values: [KeywordValues.None],
+    },
+    {
+      directive: 'block-all-mixed-content',
+    },
+    {
+      directive: 'upgrade-insecure-requests',
+    },
+  ];
+
+  return {
+    key: 'Content-Security-Policy',
+    value: joinDirectives(directives),
+  };
+}
+
+/**
+ * Returns an array of allowed script sources, which differs depending on
+ * whether the app is running via the dev server or the production server.
+ */
+function getAllowedScriptSources() {
+  const allowedScriptSources = [
+    KeywordValues.Self,
+    KeywordValues.UnsafeInline,
+    ExternalSources.RockTheVote,
+    ExternalSources.RockyAPIAssets,
+    ExternalSources.Cloudflare,
+  ];
+
+  // 'unsafe-eval' is required by Next.js when running the dev server
+  if (process.env.NODE_ENV !== 'production') {
+    allowedScriptSources.push(KeywordValues.UnsafeEval);
+  }
+
+  return allowedScriptSources;
+}
+
+/**
+ * Gets the websocket URL for Supabase Realtime. If `process.env.APP_ENV` is
+ * 'production', expects process.env.SUPABASE_PROJECT_ID to be defined.
+ *
+ * For information on the format of this URL, please see
+ * {@link https://github.com/supabase/realtime?tab=readme-ov-file#websocket-url}.
+ */
+function getSupabaseRealtimeSocketURL() {
+  if (process.env.APP_ENV === 'production') {
+    if (!process.env.SUPABASE_PROJECT_ID) {
+      throw new Error(
+        'Could not read environment variable SUPABASE_PROJECT_ID. Are you sure it has been declared?',
+      );
+    }
+
+    return `wss://${process.env.SUPABASE_PROJECT_ID}.supabase.co/realtime/`;
+  } else {
+    return 'ws://127.0.0.1:54321/realtime/';
+  }
+}
+
+/**
+ * Takes in an array of directive objects and joins them into a single string
+ * separated by semi-colons.
+ */
+function joinDirectives(directives) {
+  return directives
+    .map(({ directive, values }) => {
+      return `${values && values.length ? [directive, ...values].join(' ') : directive};`;
+    })
+    .join('');
+}

--- a/scripts/create-content-security-policy.mjs
+++ b/scripts/create-content-security-policy.mjs
@@ -9,6 +9,7 @@ const ExternalSources = {
   RockTheVote: 'https://register.rockthevote.com/',
   RockyAPIAssets: 'https://s3.amazonaws.com/rocky-assets/',
   Cloudflare: 'https://challenges.cloudflare.com/',
+  VercelTools: 'https://vercel.live/',
 };
 
 /**
@@ -93,6 +94,7 @@ function getAllowedScriptSources() {
     ExternalSources.RockTheVote,
     ExternalSources.RockyAPIAssets,
     ExternalSources.Cloudflare,
+    ExternalSources.VercelTools,
   ];
 
   // 'unsafe-eval' is required by Next.js when running the dev server

--- a/src/__tests__/unit/app/why8by8/__snapshots__/page.snapshot.tsx.snap
+++ b/src/__tests__/unit/app/why8by8/__snapshots__/page.snapshot.tsx.snap
@@ -279,7 +279,9 @@ exports[`Why8by8 renders why8by8 page unchanged 1`] = `
           <q>
             I joined the 8by8 partnerships team hoping to leverage my network and make a difference to the future of AAPI in America. Voter registration is a great starting point. My dream is to build a chain of modern and inclusive community centers for Asian Americans. With more civic engagement and political presence, the journey for modern Asian Community Centers can be easier and smoother!
           </q>
-          <aside>
+          <aside
+            style="position: relative; z-index: 2;"
+          >
             <span
               class="quote_gap_2"
             >

--- a/src/__tests__/unit/contexts/client-side-user-context-provider.test.tsx
+++ b/src/__tests__/unit/contexts/client-side-user-context-provider.test.tsx
@@ -26,6 +26,7 @@ import { mockDialogMethods } from '@/utils/test/mock-dialog-methods';
 import { VoterRegistrationForm } from '@/app/register/voter-registration-form';
 import { isErrorWithMessage } from '@/utils/shared/is-error-with-message';
 import { calculateDaysRemaining } from '@/app/progress/calculate-days-remaining';
+import { CSRF_HEADER } from '@/utils/csrf/constants';
 import type { User } from '@/model/types/user';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import type { Avatar } from '@/model/types/avatar';
@@ -150,6 +151,9 @@ describe('ClientSideUserContextProvider', () => {
       expect(fetchSpy).toHaveBeenCalledWith('/api/signup-with-email', {
         method: 'POST',
         body: JSON.stringify(signUpParams),
+        headers: {
+          [CSRF_HEADER]: expect.any(String),
+        },
       }),
     );
 
@@ -314,6 +318,9 @@ describe('ClientSideUserContextProvider', () => {
       expect(fetchSpy).toHaveBeenCalledWith('/api/send-otp-to-email', {
         method: 'POST',
         body: JSON.stringify(sendOTPToEmailParams),
+        headers: {
+          [CSRF_HEADER]: expect.any(String),
+        },
       }),
     );
 
@@ -465,6 +472,9 @@ describe('ClientSideUserContextProvider', () => {
       expect(fetchSpy).toHaveBeenCalledWith('/api/resend-otp-to-email', {
         method: 'POST',
         body: JSON.stringify({ email }),
+        headers: {
+          [CSRF_HEADER]: expect.any(String),
+        },
       }),
     );
 
@@ -639,6 +649,9 @@ describe('ClientSideUserContextProvider', () => {
       expect(fetchSpy).toHaveBeenCalledWith('/api/signin-with-otp', {
         method: 'POST',
         body: JSON.stringify({ email: expectedUser.email, otp }),
+        headers: {
+          [CSRF_HEADER]: expect.any(String),
+        },
       }),
     );
 
@@ -797,6 +810,9 @@ describe('ClientSideUserContextProvider', () => {
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith('/api/signout', {
         method: 'DELETE',
+        headers: {
+          [CSRF_HEADER]: expect.any(String),
+        },
       }),
     );
 
@@ -1036,6 +1052,7 @@ describe('ClientSideUserContextProvider', () => {
     await user.click(screen.getByText(/get reminders/i));
     expect(fetchSpy).not.toHaveBeenCalledWith(
       '/api/award-election-reminders-badge',
+      expect.anything(),
     );
     fetchSpy.mockRestore();
   });
@@ -1392,7 +1409,10 @@ describe('ClientSideUserContextProvider', () => {
     );
 
     await user.click(screen.getByText('Take the challenge'));
-    expect(fetchSpy).not.toHaveBeenCalledWith('/api/take-the-challenge');
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      '/api/take-the-challenge',
+      expect.anything(),
+    );
     fetchSpy.mockRestore();
   });
 
@@ -1444,7 +1464,10 @@ describe('ClientSideUserContextProvider', () => {
     );
 
     await user.click(screen.getByText('Take the challenge'));
-    expect(fetchSpy).not.toHaveBeenCalledWith('/api/take-the-challenge');
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      '/api/take-the-challenge',
+      expect.anything(),
+    );
     fetchSpy.mockRestore();
   });
 
@@ -1712,7 +1735,10 @@ describe('ClientSideUserContextProvider', () => {
     );
 
     await user.click(screen.getByText(/register/i));
-    expect(fetchSpy).not.toHaveBeenCalledWith('/api/register-to-vote');
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      '/api/register-to-vote',
+      expect.anything(),
+    );
     fetchSpy.mockRestore();
   });
 
@@ -2033,9 +2059,10 @@ describe('ClientSideUserContextProvider', () => {
       </AlertsContextProvider>,
     );
     await user.click(screen.getByText(/Share/i));
-    expect(fetchSpy).not.toHaveBeenCalledWith('/api/share-challenge', {
-      method: 'PUT',
-    });
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      '/api/share-challenge',
+      expect.anything(),
+    );
     fetchSpy.mockRestore();
   });
 
@@ -2227,9 +2254,10 @@ describe('ClientSideUserContextProvider', () => {
       </AlertsContextProvider>,
     );
     await user.click(screen.getByText(/restart/i));
-    expect(fetchSpy).not.toHaveBeenCalledWith('/api/restart-challenge', {
-      method: 'PUT',
-    });
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      '/api/restart-challenge',
+      expect.anything(),
+    );
     fetchSpy.mockRestore();
   });
 });

--- a/src/__tests__/unit/utils/client/read-cookie.test.ts
+++ b/src/__tests__/unit/utils/client/read-cookie.test.ts
@@ -1,0 +1,44 @@
+import { readCookie } from '@/utils/client/read-cookie';
+
+describe('readCookie', () => {
+  let setCookieSpy: any;
+  let getCookiesSpy: any;
+  let cookies = '';
+
+  beforeAll(() => {
+    setCookieSpy = jest
+      .spyOn(document, 'cookie', 'set')
+      .mockImplementation(cookie => {
+        if (cookie.includes(';')) {
+          cookies += cookie.slice(0, cookie.indexOf(';') + 1);
+        } else {
+          cookies += cookie + ';';
+        }
+      });
+
+    getCookiesSpy = jest
+      .spyOn(document, 'cookie', 'get')
+      .mockImplementation(() => {
+        return cookies;
+      });
+  });
+
+  afterEach(() => {
+    cookies = '';
+  });
+
+  afterAll(() => {
+    setCookieSpy.mockRestore();
+    getCookiesSpy.mockRestore();
+  });
+
+  it('returns the value of a cookie if one with the provided name is found.', () => {
+    document.cookie = 'name=oeschger; SameSite=None; Secure';
+    document.cookie = 'favorite_food=tripe; SameSite=None; Secure';
+    expect(readCookie('favorite_food')).toBe('tripe');
+  });
+
+  it('returns an empty string if no cookie with the provided name is found.', () => {
+    expect(readCookie('favorite_food')).toBe('');
+  });
+});

--- a/src/app/register/addresses/utils/validate-addresses.ts
+++ b/src/app/register/addresses/utils/validate-addresses.ts
@@ -1,4 +1,5 @@
 import { AddressErrorTypes } from '@/model/types/addresses/address-error-types';
+import { createCSRFHeader } from '@/utils/csrf/create-csrf-header';
 import type { ValidateAddressesParams } from '@/services/server/validate-addresses/validate-addresses';
 import type { AddressErrors } from '@/model/types/addresses/address-errors';
 
@@ -15,6 +16,7 @@ export async function validateAddresses(
     const response = await fetch('/api/validate-addresses', {
       method: 'POST',
       body: JSON.stringify(params),
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {

--- a/src/contexts/user-context/clear-invite-code-cookie.ts
+++ b/src/contexts/user-context/clear-invite-code-cookie.ts
@@ -1,5 +1,11 @@
+import { createCSRFHeader } from '@/utils/csrf/create-csrf-header';
+
+/**
+ * The invite code cookie. Can only be called from client-side code.
+ */
 export async function clearInviteCode() {
   await fetch('/api/clear-invite-code-cookie', {
     method: 'DELETE',
+    headers: createCSRFHeader(),
   });
 }

--- a/src/contexts/user-context/client-side-user-context-provider.tsx
+++ b/src/contexts/user-context/client-side-user-context-provider.tsx
@@ -13,6 +13,7 @@ import { clearInviteCode } from './clear-invite-code-cookie';
 import { clearAllPersistentFormElements, ValueOf } from 'fully-formed';
 import { VoterRegistrationForm } from '@/app/register/voter-registration-form';
 import { UserType } from '@/model/enums/user-type';
+import { createCSRFHeader } from '@/utils/csrf/create-csrf-header';
 import type { User } from '@/model/types/user';
 import type { ChallengerData } from '@/model/types/challenger-data';
 import type { RealtimeChannel } from '@supabase/supabase-js';
@@ -52,6 +53,7 @@ export function ClientSideUserContextProvider(
     const refreshUser = async () => {
       const response = await fetch('/api/refresh-user', {
         method: 'POST',
+        headers: createCSRFHeader(),
       });
 
       if (response.ok) {
@@ -111,6 +113,7 @@ export function ClientSideUserContextProvider(
     const response = await fetch('/api/signup-with-email', {
       method: 'POST',
       body: JSON.stringify(params),
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -129,6 +132,7 @@ export function ClientSideUserContextProvider(
     const response = await fetch('/api/send-otp-to-email', {
       method: 'POST',
       body: JSON.stringify(params),
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -147,6 +151,7 @@ export function ClientSideUserContextProvider(
     const response = await fetch('/api/resend-otp-to-email', {
       method: 'POST',
       body: JSON.stringify({ email: emailForSignIn }),
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -162,6 +167,7 @@ export function ClientSideUserContextProvider(
     const response = await fetch('/api/signin-with-otp', {
       method: 'POST',
       body: JSON.stringify({ email: emailForSignIn, otp }),
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -180,6 +186,7 @@ export function ClientSideUserContextProvider(
   async function signOut() {
     const response = await fetch('/api/signout', {
       method: 'DELETE',
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -196,6 +203,7 @@ export function ClientSideUserContextProvider(
 
     const response = await fetch('/api/award-election-reminders-badge', {
       method: 'PUT',
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -214,6 +222,7 @@ export function ClientSideUserContextProvider(
 
     const response = await fetch('/api/share-challenge', {
       method: 'PUT',
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -235,6 +244,7 @@ export function ClientSideUserContextProvider(
     const response = await fetch('/api/register-to-vote', {
       method: 'POST',
       body: JSON.stringify(formData),
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -259,6 +269,7 @@ export function ClientSideUserContextProvider(
 
     const response = await fetch('/api/take-the-challenge', {
       method: 'PUT',
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {
@@ -277,6 +288,7 @@ export function ClientSideUserContextProvider(
 
     const response = await fetch('/api/restart-challenge', {
       method: 'PUT',
+      headers: createCSRFHeader(),
     });
 
     if (!response.ok) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,6 +11,7 @@ import type { NextRequest, NextFetchEvent } from 'next/server';
  */
 export async function middleware(request: NextRequest, event: NextFetchEvent) {
   return await middlewares.chainMiddleware([
+    middlewares.csrfProtection,
     middlewares.rateLimit,
     middlewares.setInviteCodeCookie,
     middlewares.isSignedOut,

--- a/src/middlewares/csrf-protection.ts
+++ b/src/middlewares/csrf-protection.ts
@@ -1,0 +1,54 @@
+import { PRIVATE_ENVIRONMENT_VARIABLES } from '@/constants/private-environment-variables';
+import { CSRF_COOKIE } from '@/utils/csrf/constants';
+import { createCSRFToken } from '@/utils/csrf/create-csrf-token';
+import { validateCSRFToken } from '@/utils/csrf/validate-csrf-tokens';
+import {
+  NextResponse,
+  type NextRequest,
+  type NextFetchEvent,
+} from 'next/server';
+import type { ChainedMiddleware } from './chained-middleware';
+
+/**
+ * Provides simple protection again CSRF attacks using the double-submit token
+ * pattern.
+ *
+ * For more information, please see
+ * {@link https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html}
+ */
+export function csrfProtection(next: ChainedMiddleware): ChainedMiddleware {
+  return (
+    request: NextRequest,
+    event: NextFetchEvent,
+    response?: NextResponse,
+  ) => {
+    /*
+      If the route is an API route, verify the token. Prevent the user from 
+      accessing the route if they do not have a valid token.
+    */
+    if (request.nextUrl.pathname.startsWith('/api')) {
+      if (!validateCSRFToken(request)) {
+        return NextResponse.json(
+          { error: 'Invalid CSRF token.' },
+          { status: 403 },
+        );
+      }
+    } else {
+      /*
+        Otherwise, if the route is not an API route, set a token as a cookie.
+        httpOnly must be false so that client-side code can read the cookie and 
+        set it as a header, but sameSite must be strict to prevent attackers 
+        from accessing its value.
+      */
+      if (!response) response = NextResponse.next();
+
+      response?.cookies.set(CSRF_COOKIE, createCSRFToken(), {
+        httpOnly: false,
+        sameSite: 'strict',
+        secure: PRIVATE_ENVIRONMENT_VARIABLES.APP_ENV === 'production',
+      });
+    }
+
+    return next(request, event, response);
+  };
+}

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,4 +1,5 @@
 export { chainMiddleware } from './chain-middleware';
+export { csrfProtection } from './csrf-protection';
 export { hasNotRegistered } from './has-not-registered';
 export { hasNotSignedUpForReminders } from './has-not-signed-up-for-reminders';
 export { hasRegistered } from './has-registered';

--- a/src/utils/client/read-cookie.ts
+++ b/src/utils/client/read-cookie.ts
@@ -1,0 +1,14 @@
+export function readCookie(name: string): string {
+  name += '=';
+  let decodedCookie = decodeURIComponent(document.cookie);
+  let cookies = decodedCookie.split(';');
+
+  for (const cookie of cookies) {
+    const indexOfName = cookie.indexOf(name);
+    if (indexOfName === -1) continue;
+
+    return cookie.substring(indexOfName + name.length);
+  }
+
+  return '';
+}

--- a/src/utils/csrf/constants.ts
+++ b/src/utils/csrf/constants.ts
@@ -1,0 +1,2 @@
+export const CSRF_HEADER = `X-CSRF-TOKEN`;
+export const CSRF_COOKIE = '8by8-csrf-token';

--- a/src/utils/csrf/create-csrf-header.ts
+++ b/src/utils/csrf/create-csrf-header.ts
@@ -1,0 +1,15 @@
+import { readCookie } from '../client/read-cookie';
+import { CSRF_COOKIE, CSRF_HEADER } from './constants';
+
+/**
+ * Can only be called from client-side code. Reads a CSRF token from a cookie
+ * and returns an object that can be provided to the headers property of the
+ * options object for a fetch request.
+ */
+export function createCSRFHeader() {
+  const token = readCookie(CSRF_COOKIE);
+
+  return {
+    [CSRF_HEADER]: token,
+  };
+}

--- a/src/utils/csrf/create-csrf-token.ts
+++ b/src/utils/csrf/create-csrf-token.ts
@@ -1,0 +1,17 @@
+/**
+ * Generates a crypographically secure random value to be used as a CSRF token.
+ */
+export function createCSRFToken() {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  const token = toHex(bytes);
+  return token;
+}
+
+/**
+ * Converts a Uint8Array into a hexadecimal string.
+ */
+function toHex(uInt8Arr: Uint8Array) {
+  return Array.from(uInt8Arr)
+    .map(i => i.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/src/utils/csrf/validate-csrf-tokens.ts
+++ b/src/utils/csrf/validate-csrf-tokens.ts
@@ -1,0 +1,11 @@
+import { CSRF_COOKIE, CSRF_HEADER } from './constants';
+import type { NextRequest } from 'next/server';
+
+export function validateCSRFToken(request: NextRequest) {
+  const cookie = request.cookies.get(CSRF_COOKIE);
+  const header = request.headers.get(CSRF_HEADER);
+
+  if (!cookie || !cookie.value || !header) return false;
+
+  return header === cookie.value;
+}


### PR DESCRIPTION
## Checklist
- [x] Include the corresponding Jira issue key and #done in the PR title, like so: "JRA-123 #done Migrate Election Reminders"
- [x] Verify that the code compiles (npm run dev)
- [x] Verify that the project builds (npm run build:local)
- [x] Verify that all tests pass
- [x] Verify that unit tests cover 100% of the code
- [ ] <s>Create Storybook stories for visual components</s> N/A
- [ ] <s>Verify that any visual components match the Figma</s> N/A
- [ ] <s>Test with a screen reader (if applicable)</s> N/A
- [x] Document your code with TSDoc comments
- [x] Format your code with Prettier

## Overview
This PR adds a script that dynamically generates a content security policy header, depending on the environment in which the project was built. Resources from the page itself, Rock the Vote, Rock the Vote's Rocky API, Cloudflare Turnstile, Supabase Realtime, and Vercel Toolbar are allowed, all others are denied.

Middleware is added to protect API routes from CSRF attacks with the double-submit token pattern.

## Test Plan
I verified that requests to api routes without a valid CSRF token were blocked and that scripts not allowed in the CSP were also blocked.

## Follow ups
Could implement the signed double-submit token pattern in the future to enhance security.
