### PR TITLE
Fix failing workflow

### DIFF
--- a/.github/workflows/ping-supabase.yml
+++ b/.github/workflows/ping-supabase.yml
@@ -4,16 +4,10 @@ name: 'Ping Supabase'
 
 on:
   workflow_call:
-    inputs:
-      environment-name:
-        type: string
-        required: true
-
+  
 jobs:
   ping:
     runs-on: ubuntu-latest
-    environment: 
-      name: ${{ inputs.environment-name }}
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/.github/workflows/ping-supabase.yml
+++ b/.github/workflows/ping-supabase.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   ping:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment-name }}
+    environment: 
+      name: ${{ inputs.environment-name }}
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/.github/workflows/ping-supabase.yml
+++ b/.github/workflows/ping-supabase.yml
@@ -4,10 +4,20 @@ name: 'Ping Supabase'
 
 on:
   workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+    secrets:
+      SUPABASE_URL:
+        required: true
+      SUPABASE_ANON_KEY:
+        required: true
   
 jobs:
   ping:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/.github/workflows/ping-supabase.yml
+++ b/.github/workflows/ping-supabase.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - run: npm ci

--- a/.github/workflows/schedule-supabase-pings.yml
+++ b/.github/workflows/schedule-supabase-pings.yml
@@ -1,6 +1,7 @@
 name: 'Schedule Supabase Pings'
 
 on:
+  workflow_dispatch:
   schedule:
     # Run this job at 4:30 AM UTC every Sunday and Thursday. Scheduled jobs are
     # often delayed and can be dropped during peak times (see

--- a/.github/workflows/schedule-supabase-pings.yml
+++ b/.github/workflows/schedule-supabase-pings.yml
@@ -16,9 +16,15 @@ jobs:
   ping-staging:
     uses: ./.github/workflows/ping-supabase.yml
     with:
-      environment-name: staging
+      environment: staging
+    secrets:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
 
   ping-prod:
     uses: ./.github/workflows/ping-supabase.yml
     with:
-      environment-name: production
+      environment: production
+    secrets:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## Overview
This commit updates the Github workflows that ping Supabase and adds a "workflow_dispatch" trigger, enabling them to be tested immediately upon merge instead of requiring the developer to wait until their scheduled run takes place to verify their behavior.

The workflows were failing because secrets must be passed explicity to re-usable workflows even if the name of an environment is passed as an input.

## Test Plan
I manually ran the workflows in my repository and they passed.
![successful runs](https://github.com/user-attachments/assets/f07f3fd9-56f0-4738-8bbe-778dab78a4d0)

