### PR TITLE
CHAL-84 #done - Bug fix

### DIFF
--- a/scripts/create-content-security-policy.mjs
+++ b/scripts/create-content-security-policy.mjs
@@ -34,7 +34,11 @@ export function createCSP() {
         widget to be rendered in IFrames.
       */
       directive: 'frame-src',
-      values: [ExternalSources.RockTheVote, ExternalSources.Cloudflare],
+      values: [
+        ExternalSources.RockTheVote,
+        ExternalSources.Cloudflare,
+        ExternalSources.VercelTools,
+      ],
     },
     {
       directive: 'connect-src',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,8 @@ interface RootLayoutProps {
 
 export const metadata: Metadata = {
   title: '8by8 Challenge',
+  description:
+    'Join us in promoting civic engagement to combat hate against the AAPI community. Register to vote, sign up for election reminders, and share your challenge to earn badges. Together, we can make a difference! Made by 8by8.us with ❤️',
   openGraph: {
     images: {
       url: '/static/images/open-graph/thumbnail.png',

--- a/src/middlewares/set-invite-code-cookie.ts
+++ b/src/middlewares/set-invite-code-cookie.ts
@@ -25,7 +25,7 @@ export function setInviteCodeCookie(
       const response = NextResponse.redirect(request.nextUrl);
       response.cookies.set(CookieNames.InviteCode, inviteCode, {
         httpOnly: true,
-        sameSite: 'strict',
+        sameSite: 'lax',
         secure: PRIVATE_ENVIRONMENT_VARIABLES.APP_ENV === 'production',
       });
 


### PR DESCRIPTION
## Checklist
- [x] Include the corresponding Jira issue key and #done in the PR title, like so: "JRA-123 #done Migrate Election Reminders"
- [x] Verify that the code compiles (npm run dev)
- [x] Verify that the project builds (npm run build:local)
- [x] Verify that all tests pass
- [x] Verify that unit tests cover 100% of the code
- [ ] <s>Create Storybook stories for visual components</s> N/A
- [ ] <s>Verify that any visual components match the Figma</s> N/A
- [ ] <s>Test with a screen reader (if applicable)</s> N/A
- [x] Document your code with TSDoc comments
- [x] Format your code with Prettier

## Overview
When clicking a user's invitation link, the appropriate invitedBy information was not rendered in the UI even though the invitedCode cookie was set. Navigating directly to the same link via the browser's search bar did **not** pose the same issue. The problem was that, though the server was setting the cookie and then redirecting the user to /playerwelcome, the cookie was not being sent together with the redirected request since its same site policy was set to "strict." Setting this policy to "lax" allows the cookie to be sent when following an external link, but provides greater protection than "none" for other types of requests.

A few other minor fixes have been made:
- A description meta tag has been provided to boost SEO.
- vercel.live has been added to allowed frame sources in the script that generates the content security policy. This enables the Vercel tools to render for authenticated members of the team.

## Test Plan
I verified that invitation links now work as expected using my own deployment of the application to test. 

## Follow ups
I noticed a console error that I have not been able to replicate. The error indicated that a request was made to a subdomain of supabase.co to generate a refresh token, but that that request was denied because of the CSP. We should keep an eye on the console so that we can update the CSP script appropriately to fix this. We may also want to implement a more robust logging solution.
