### PR TITLE
Update @supabase/ssr version, add /homepage to redirects array

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,16 @@ const nextConfig = {
         destination: '/register/eligibility',
         permanent: true,
       },
+      {
+        /*
+          The Wix site (https://8by8.us) contains a link to /homepage, which 
+          doesn't exist in the new 8by8 challenge application. Redirect to 
+          / for now until the Wix site can be updated. 
+        */
+        source: '/homepage',
+        destination: '/',
+        permanent: true,
+      },
     ];
   },
 };

--- a/src/services/server/create-supabase-client/create-supabase-ssr-client.ts
+++ b/src/services/server/create-supabase-client/create-supabase-ssr-client.ts
@@ -33,9 +33,19 @@ export const createSupabaseSSRClient = bind(
           return cookieStore.getAll();
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) =>
-            cookieStore.set(name, value, options),
-          );
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            /* 
+              The `setAll` method was called from a Server Component.
+              This error can be ignored because we have middleware that 
+              refreshes the user. For more information, see:
+
+              https://supabase.com/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=nextjs&queryGroups=environment&environment=server#create-a-client
+            */
+          }
         },
       },
     });


### PR DESCRIPTION
## Checklist
- [ ] <s>Include the corresponding Jira issue key and #done in the PR title, like so: "JRA-123 #done Migrate Election Reminders"</s> N/A
- [x] Verify that the code compiles (npm run dev)
- [x] Verify that the project builds (npm run build:local)
- [x] Verify that all tests pass
- [x] Verify that unit tests cover 100% of the code
- [ ] <s>Create Storybook stories for visual components</s> N/A
- [ ] <s>Verify that any visual components match the Figma</s> N/A
- [ ] <s>Test with a screen reader (if applicable)</s> N/A
- [x] Document your code with TSDoc comments
- [x] Format your code with Prettier

## Overview
This PR updates the @supabase/ssr version to version 0.5.1 and updates the usage of said package to reflect the latest example provided by the Supabase docs. The original example was causing intermittent 500 errors because cookies were being set in a Server component, which is not allowed in Next.js and throws an exception. The new docs for this package indicate that the logic inside the `setAll` method provided to `createServerClient`  should be wrapped in a `try...catch` block to avoid this situation.

Here is a screenshot of the error:
![unhandled rejection](https://github.com/user-attachments/assets/a4e5355d-71ea-4d2d-8209-ee3cb4cd6e85)

The updated docs can be viewed [here](https://supabase.com/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=nextjs&queryGroups=environment&environment=server#create-a-client
).

This PR also adds `/homepage` to the `redirects` array in `next.config.mjs`. `/homepage` redirects to `/`. This is necessary because the main 8by8 site (https://8by8.us) contains links to the challenge application. These links currently point to `/homepage`. Until the main site can be updated, we should redirect users coming from `/homepage` so that they don't hit our 404 page.

## Test Plan
All unit tests pass. I verified that a user visiting `/homepage` is redirected to `/`.

## Follow ups
We should continue to monitor Vercel logs.
